### PR TITLE
README.md: Fix a typo (“extention” → “extension”)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# VALE BPF Extention Module
-VALE-BPF module is an extention of VALE software switch.
+# VALE BPF Extension Module
+VALE-BPF module is an extension of VALE software switch.
 
 This module makes VALE possible to program with eBPF.
 


### PR DESCRIPTION
Just to fix a typo in the main description of the project. It looks really interesting, by the way! 👍 